### PR TITLE
Add basic consent_url method and handling

### DIFF
--- a/envelope_sending_demo.py
+++ b/envelope_sending_demo.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 from docusign_esign import EnvelopesApi, EnvelopeDefinition, TemplateRole
 from docusign_esign.client.api_exception import ApiException
-from jwt_utils import get_base_api_client, get_config
+from jwt_utils import get_base_api_client, get_config, get_consent_url
 
 
 def create_envelope_definition() -> EnvelopeDefinition:
@@ -62,6 +62,17 @@ def main() -> None:
         print(err)
         body = err.body.decode("utf8")
         print(body)
+        print("")
+        print("Checking for consent....")
+        # Each application needs to get "consent" from the impersonated user.
+        # This appears to be needed only one, on the first run.
+        # TODO: This, better...
+        if "consent_required" in body:
+            consent_url = get_consent_url(scopes, config)
+            print(
+                "Open the following URL in your browser to grant consent to the application:"
+            )
+            print(consent_url)
 
 
 if __name__ == "__main__":

--- a/get_form_data.py
+++ b/get_form_data.py
@@ -8,7 +8,7 @@ from docusign_esign import (
     FormDataItem,
 )
 from docusign_esign.client.api_exception import ApiException
-from jwt_utils import get_base_api_client, get_config
+from jwt_utils import get_base_api_client, get_config, get_consent_url
 
 
 def get_form_data_from_envelope(envelope_form_data: EnvelopeFormData) -> dict:
@@ -30,11 +30,11 @@ def main() -> None:
     args = parser.parse_args()
     config = get_config(args.config)
 
-    scopes = ["signature", "impersonation"]
-    api_client = get_base_api_client(scopes, config)
-    account_id = api_client.account_id
-
     try:
+        scopes = ["signature", "impersonation"]
+        api_client = get_base_api_client(scopes, config)
+        account_id = api_client.account_id
+
         folders_api = FoldersApi(api_client)
         # folders = folders_api.list(account_id)
         # Could also limit this by date and sender, but not subject.
@@ -65,6 +65,17 @@ def main() -> None:
         print(err)
         body = err.body.decode("utf8")
         print(body)
+        print("")
+        print("Checking for consent....")
+        # Each application needs to get "consent" from the impersonated user.
+        # This appears to be needed only one, on the first run.
+        # TODO: This, better...
+        if "consent_required" in body:
+            consent_url = get_consent_url(scopes, config)
+            print(
+                "Open the following URL in your browser to grant consent to the application:"
+            )
+            print(consent_url)
 
 
 if __name__ == "__main__":

--- a/jwt_utils.py
+++ b/jwt_utils.py
@@ -52,6 +52,19 @@ def get_base_api_client(scopes: list[str], config: dict) -> ApiClient:
     return api_client
 
 
+def get_consent_url(scopes: list[str], config: dict):
+    # Adapted from https://github.com/docusign/code-examples-python/blob/master/jwt_console.py
+    url_scopes = "+".join(scopes)
+    # This redirect_uri must also be added to the application in Docusign.
+    redirect_uri = "https://developers.docusign.com/platform/auth/consent"
+    # Construct consent URL
+    consent_url = (
+        f"https://{config['authorization_server']}/oauth/auth?response_type=code&"
+        f"scope={url_scopes}&client_id={config['client_id']}&redirect_uri={redirect_uri}"
+    )
+    return consent_url
+
+
 def dump_template_info(
     api_client: ApiClient, account_id: str, template: EnvelopeTemplate
 ) -> None:


### PR DESCRIPTION
Adds `jwt_utils.get_consent_url()` and basic exception handling.  This is needed the first time an application is accessed.  This is not production-ready, just enough to move forward.
